### PR TITLE
cherry-pick 41c6b... - add client startup time

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -330,6 +330,7 @@ bool AppInit2(int argc, char* argv[])
         ShrinkDebugFile();
     printf("\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n");
     printf("PPCoin version %s (%s)\n", FormatFullVersion().c_str(), CLIENT_DATE.c_str());
+    printf("Startup time: %s\n", DateTimeStrFormat("%x %H:%M:%S", GetTime()).c_str());
     printf("Default data directory %s\n", GetDefaultDataDir().string().c_str());
 
     if (GetBoolArg("-loadblockindextest"))

--- a/src/qt/clientmodel.cpp
+++ b/src/qt/clientmodel.cpp
@@ -8,6 +8,8 @@
 
 #include <QDateTime>
 
+static const int64_t nClientStartupTime = GetTime();
+
 ClientModel::ClientModel(OptionsModel *optionsModel, QObject *parent) :
     QObject(parent), optionsModel(optionsModel),
     cachedNumConnections(0), cachedNumBlocks(0)
@@ -98,3 +100,9 @@ QString ClientModel::clientName() const
 {
     return QString::fromStdString(CLIENT_NAME);
 }
+
+QString ClientModel::formatClientStartupTime() const
+{
+    return QDateTime::fromTime_t(nClientStartupTime).toString();
+}
+

--- a/src/qt/clientmodel.h
+++ b/src/qt/clientmodel.h
@@ -39,6 +39,7 @@ public:
     QString formatFullVersion() const;
     QString formatBuildDate() const;
     QString clientName() const;
+    QString formatClientStartupTime() const;
 
 private:
     OptionsModel *optionsModel;

--- a/src/qt/forms/rpcconsole.ui
+++ b/src/qt/forms/rpcconsole.ui
@@ -80,7 +80,7 @@
          </property>
         </widget>
        </item>
-       <item row="4" column="0">
+       <item row="5" column="0">
         <widget class="QLabel" name="label_11">
          <property name="font">
           <font>
@@ -93,14 +93,14 @@
          </property>
         </widget>
        </item>
-       <item row="5" column="0">
+       <item row="6" column="0">
         <widget class="QLabel" name="label_7">
          <property name="text">
           <string>Number of connections</string>
          </property>
         </widget>
        </item>
-       <item row="5" column="1">
+       <item row="6" column="1">
         <widget class="QLabel" name="numberOfConnections">
          <property name="text">
           <string>N/A</string>
@@ -113,14 +113,14 @@
          </property>
         </widget>
        </item>
-       <item row="6" column="0">
+       <item row="7" column="0">
         <widget class="QLabel" name="label_8">
          <property name="text">
           <string>On testnet</string>
          </property>
         </widget>
        </item>
-       <item row="6" column="1">
+       <item row="7" column="1">
         <widget class="QCheckBox" name="isTestNet">
          <property name="enabled">
           <bool>false</bool>
@@ -130,7 +130,7 @@
          </property>
         </widget>
        </item>
-       <item row="7" column="0">
+       <item row="8" column="0">
         <widget class="QLabel" name="label_10">
          <property name="font">
           <font>
@@ -143,14 +143,14 @@
          </property>
         </widget>
        </item>
-       <item row="8" column="0">
+       <item row="9" column="0">
         <widget class="QLabel" name="label_3">
          <property name="text">
           <string>Current number of blocks</string>
          </property>
         </widget>
        </item>
-       <item row="8" column="1">
+       <item row="9" column="1">
         <widget class="QLabel" name="numberOfBlocks">
          <property name="text">
           <string>N/A</string>
@@ -163,14 +163,14 @@
          </property>
         </widget>
        </item>
-       <item row="9" column="0">
+       <item row="10" column="0">
         <widget class="QLabel" name="label_4">
          <property name="text">
           <string>Estimated total blocks</string>
          </property>
         </widget>
        </item>
-       <item row="9" column="1">
+       <item row="10" column="1">
         <widget class="QLabel" name="totalBlocks">
          <property name="text">
           <string>N/A</string>
@@ -183,14 +183,14 @@
          </property>
         </widget>
        </item>
-       <item row="10" column="0">
+       <item row="11" column="0">
         <widget class="QLabel" name="label_2">
          <property name="text">
           <string>Last block time</string>
          </property>
         </widget>
        </item>
-       <item row="10" column="1">
+       <item row="11" column="1">
         <widget class="QLabel" name="lastBlockTime">
          <property name="text">
           <string>N/A</string>
@@ -203,7 +203,7 @@
          </property>
         </widget>
        </item>
-       <item row="11" column="0">
+       <item row="12" column="0">
         <spacer name="verticalSpacer">
          <property name="orientation">
           <enum>Qt::Vertical</enum>
@@ -227,6 +227,29 @@
         <widget class="QLabel" name="buildDate">
          <property name="text">
           <string>N/A</string>
+         </property>
+        </widget>
+       </item>
+       <item row="4" column="0">
+        <widget class="QLabel" name="label_13">
+         <property name="text">
+          <string>Startup time</string>
+         </property>
+        </widget>
+       </item>
+       <item row="4" column="1">
+        <widget class="QLabel" name="startupTime">
+         <property name="cursor">
+          <cursorShape>IBeamCursor</cursorShape>
+         </property>
+         <property name="text">
+          <string>N/A</string>
+         </property>
+         <property name="textFormat">
+          <enum>Qt::PlainText</enum>
+         </property>
+         <property name="textInteractionFlags">
+          <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
          </property>
         </widget>
        </item>

--- a/src/qt/rpcconsole.cpp
+++ b/src/qt/rpcconsole.cpp
@@ -256,6 +256,7 @@ void RPCConsole::setClientModel(ClientModel *model)
         ui->clientVersion->setText(model->formatFullVersion());
         ui->clientName->setText(model->clientName());
         ui->buildDate->setText(model->formatBuildDate());
+        ui->startupTime->setText(model->formatClientStartupTime());
 
         setNumConnections(model->getNumConnections());
         ui->isTestNet->setChecked(model->isTestNet());


### PR DESCRIPTION
cherry-pick 41c6b8abc60f90e73ae4ad89b0a922638a61bbea (add client startup time)
w/ conflicts

add client startup time as an entry to debug.log (note: logged time in debug.log differs by a few seconds from the one displayed in the Debug window) / make ClientModel::formatClientStartupTime() return a QString
Author:    Philip Kaufmann phil.kaufmann@t-online.de

Conflicts:
    src/init.cpp
    src/qt/clientmodel.cpp
    src/qt/clientmodel.h
    src/qt/rpcconsole.cpp
